### PR TITLE
fix: address sync review comments

### DIFF
--- a/src/config/sync.test.ts
+++ b/src/config/sync.test.ts
@@ -5,23 +5,29 @@
  */
 
 import { describe, it, expect, mock } from "bun:test";
-import { syncPiConfig, type SyncDeps } from "./sync";
+import { syncPiConfig, rewriteLocalHosts, type SyncDeps } from "./sync";
 
 function makeDeps(overrides: Partial<SyncDeps> = {}): {
   deps: SyncDeps;
   logSpy: ReturnType<typeof mock>;
   copySpy: ReturnType<typeof mock>;
   rmSpy: ReturnType<typeof mock>;
+  readFileSpy: ReturnType<typeof mock>;
+  writeFileSpy: ReturnType<typeof mock>;
 } {
   const logSpy = overrides.log ?? mock((_msg: string) => {});
   const copySpy = overrides.copy ?? mock(async (_src: string, _dest: string) => {});
   const rmSpy = overrides.rm ?? mock(async (_p: string) => {});
+  const readFileSpy = overrides.readFile ?? mock(async (_p: string) => "{}");
+  const writeFileSpy = overrides.writeFile ?? mock(async (_p: string, _content: string) => {});
 
   const deps: SyncDeps = {
     homedir: overrides.homedir ?? (() => "/home/testuser"),
     exists: overrides.exists ?? (async (_p: string) => true),
     copy: copySpy as SyncDeps["copy"],
     rm: rmSpy as SyncDeps["rm"],
+    readFile: readFileSpy as SyncDeps["readFile"],
+    writeFile: writeFileSpy as SyncDeps["writeFile"],
     log: logSpy as SyncDeps["log"],
   };
 
@@ -30,6 +36,8 @@ function makeDeps(overrides: Partial<SyncDeps> = {}): {
     logSpy: logSpy as ReturnType<typeof mock>,
     copySpy: copySpy as ReturnType<typeof mock>,
     rmSpy: rmSpy as ReturnType<typeof mock>,
+    readFileSpy: readFileSpy as ReturnType<typeof mock>,
+    writeFileSpy: writeFileSpy as ReturnType<typeof mock>,
   };
 }
 
@@ -136,5 +144,155 @@ describe("syncPiConfig", () => {
       const [, dest] = copySpy.mock.calls[0] as [string, string];
       expect(dest).toBe("/custom/dest/.pi");
     });
+  });
+
+  describe("models.json transformation", () => {
+    it("transforms 127.0.0.1 to host.docker.internal in models.json", async () => {
+      const modelsContent = JSON.stringify({
+        providers: {
+          ollama: {
+            baseUrl: "http://127.0.0.1:11434/v1",
+          },
+        },
+      });
+
+      const { deps, readFileSpy, writeFileSpy, logSpy } = makeDeps({
+        // Both ~/.pi (src) and models.json exist
+        exists: async () => true,
+        readFile: mock(async (p: string) => {
+          if (p.includes("models.json")) return modelsContent;
+          return "{}";
+        }),
+      });
+
+      await syncPiConfig("/project/.pi", deps);
+
+      expect(readFileSpy).toHaveBeenCalledWith("/project/.pi/agent/models.json");
+      expect(writeFileSpy).toHaveBeenCalled();
+      const [writtenPath, writtenContent] = writeFileSpy.mock.calls[0] as [string, string];
+      expect(writtenPath).toBe("/project/.pi/agent/models.json");
+      expect(writtenContent).toContain("host.docker.internal");
+      expect(writtenContent).not.toContain("127.0.0.1");
+      expect(logSpy.mock.calls.some((call) =>
+        (call[0] as string).includes("Transformed models.json")
+      )).toBe(true);
+    });
+
+    it("transforms localhost to host.docker.internal in models.json", async () => {
+      const modelsContent = JSON.stringify({
+        providers: {
+          ollama: {
+            baseUrl: "http://localhost:11434/v1",
+          },
+        },
+      });
+
+      const { deps, writeFileSpy } = makeDeps({
+        exists: async () => true,
+        readFile: mock(async (p: string) =>
+          p.includes("models.json") ? modelsContent : "{}"
+        ),
+      });
+
+      await syncPiConfig("/project/.pi", deps);
+
+      const [, writtenContent] = writeFileSpy.mock.calls[0] as [string, string];
+      expect(writtenContent).toContain("host.docker.internal");
+      expect(writtenContent).not.toContain("localhost");
+    });
+
+    it("does not write models.json if no transformation needed", async () => {
+      const modelsContent = JSON.stringify({
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+          },
+        },
+      });
+
+      const { deps, writeFileSpy } = makeDeps({
+        exists: async () => true,
+        readFile: mock(async (p: string) =>
+          p.includes("models.json") ? modelsContent : "{}"
+        ),
+      });
+
+      await syncPiConfig("/project/.pi", deps);
+
+      expect(writeFileSpy).not.toHaveBeenCalled();
+    });
+
+    it("handles missing models.json gracefully", async () => {
+      const { deps, readFileSpy } = makeDeps({
+        exists: mock(async (p: string) => !p.includes("models.json")),
+      });
+
+      await syncPiConfig("/project/.pi", deps);
+
+      expect(readFileSpy).not.toHaveBeenCalled();
+    });
+
+    it("logs a warning when writeFile throws instead of silently failing", async () => {
+      const modelsContent = JSON.stringify({
+        providers: { ollama: { baseUrl: "http://127.0.0.1:11434/v1" } },
+      });
+
+      const { deps, logSpy } = makeDeps({
+        exists: async () => true,
+        readFile: mock(async (p: string) =>
+          p.includes("models.json") ? modelsContent : "{}"
+        ),
+        writeFile: mock(async () => { throw new Error("EACCES: permission denied"); }),
+      });
+
+      // Must not throw
+      await expect(syncPiConfig("/project/.pi", deps)).resolves.toBeUndefined();
+
+      // Must log a warning containing the error message
+      expect(logSpy.mock.calls.some((call) =>
+        (call[0] as string).toLowerCase().includes("warning") &&
+        (call[0] as string).includes("EACCES")
+      )).toBe(true);
+    });
+  });
+});
+
+// ── rewriteLocalHosts unit tests ──────────────────────────────────────────
+
+describe("rewriteLocalHosts", () => {
+  it("replaces 127.0.0.1 with host.docker.internal", () => {
+    expect(rewriteLocalHosts('{"baseUrl":"http://127.0.0.1:11434/v1"}')).toBe(
+      '{"baseUrl":"http://host.docker.internal:11434/v1"}'
+    );
+  });
+
+  it("replaces localhost with host.docker.internal", () => {
+    expect(rewriteLocalHosts('{"baseUrl":"http://localhost:11434/v1"}')).toBe(
+      '{"baseUrl":"http://host.docker.internal:11434/v1"}'
+    );
+  });
+
+  it("replaces all occurrences in the same string", () => {
+    const input = '{"a":"http://127.0.0.1:1234","b":"http://localhost:5678"}';
+    const result = rewriteLocalHosts(input);
+    expect(result).not.toContain("127.0.0.1");
+    expect(result).not.toContain("localhost");
+    expect(result.match(/host\.docker\.internal/g)?.length).toBe(2);
+  });
+
+  it("returns the string unchanged when no local addresses are present", () => {
+    const input = '{"baseUrl":"https://api.openai.com/v1"}';
+    expect(rewriteLocalHosts(input)).toBe(input);
+  });
+
+  it("does not corrupt a model id that contains 'localhost' as a substring", () => {
+    // e.g. a provider or model name that happens to include "localhost"
+    const input = '{"id":"my-localhost-model","baseUrl":"http://localhost:11434"}';
+    const result = rewriteLocalHosts(input);
+    // The URL should be rewritten
+    expect(result).toContain("host.docker.internal");
+    // But the model id must NOT be touched — "localhost" inside a word boundary
+    // should not be replaced
+    expect(result).toContain("my-localhost-model");
   });
 });

--- a/src/config/sync.ts
+++ b/src/config/sync.ts
@@ -23,6 +23,10 @@ export interface SyncDeps {
   rm: (p: string) => Promise<void>;
   /** Recursively copies src into dest (dest must not exist beforehand) */
   copy: (src: string, dest: string) => Promise<void>;
+  /** Read file contents */
+  readFile: (p: string) => Promise<string>;
+  /** Write file contents */
+  writeFile: (p: string, content: string) => Promise<void>;
   /** Log output function */
   log: (msg: string) => void;
 }
@@ -43,8 +47,32 @@ const defaultDeps: SyncDeps = {
   rm: (p: string) => fs.promises.rm(p, { recursive: true, force: true }),
   copy: (src: string, dest: string) =>
     fs.promises.cp(src, dest, { recursive: true }),
+  readFile: (p: string) => fs.promises.readFile(p, "utf-8"),
+  writeFile: (p: string, content: string) => fs.promises.writeFile(p, content, "utf-8"),
   log: console.log,
 };
+
+/**
+ * Rewrites local-only hostnames in a models.json string so they resolve
+ * correctly from inside a Docker container.
+ *
+ * Replaces:
+ *  - `127.0.0.1`  → `host.docker.internal`
+ *  - `localhost`  → `host.docker.internal`
+ *
+ * The `localhost` match uses negative lookbehind/lookahead for `[a-zA-Z0-9-]`
+ * so that hyphenated strings like `"my-localhost-model"` are left untouched
+ * while URL hostnames like `http://localhost:11434` are rewritten correctly.
+ * (`\b` alone is insufficient because hyphens are not word characters.)
+ *
+ * @param content - Raw string contents of models.json
+ * @returns Transformed string (identical to input if no replacements made)
+ */
+export function rewriteLocalHosts(content: string): string {
+  return content
+    .replace(/127\.0\.0\.1/g, "host.docker.internal")
+    .replace(/(?<![a-zA-Z0-9-])localhost(?![a-zA-Z0-9-])/g, "host.docker.internal");
+}
 
 /**
  * Syncs ~/.pi into the given dest directory before a Docker build.
@@ -77,4 +105,23 @@ export async function syncPiConfig(
   deps.log(`Copying ~/.pi → ${dest}...`);
   await deps.rm(dest);
   await deps.copy(src, dest);
+
+  // Transform models.json for Docker: replace local addresses with host.docker.internal
+  const modelsPath = path.join(dest, "agent", "models.json");
+  if (await deps.exists(modelsPath)) {
+    try {
+      const content = await deps.readFile(modelsPath);
+      const transformed = rewriteLocalHosts(content);
+      if (content !== transformed) {
+        await deps.writeFile(modelsPath, transformed);
+        deps.log("Transformed models.json for Docker container access");
+      }
+    } catch (err) {
+      // Log a warning — silently ignoring I/O errors here would leave the
+      // container running with 127.0.0.1 addresses with no indication of failure.
+      deps.log(
+        `Warning: could not transform models.json: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Addresses all 7 review comments raised against the uncommitted `syncPiConfig` / `rewriteLocalHosts` changes.

## Changes

### `src/config/sync.ts`
- **[CRITICAL]** Replace bare `catch {}` with `catch (err)` that logs a `Warning:` message — a `writeFile` failure (e.g. EACCES, disk full) no longer silently leaves the container misconfigured with `127.0.0.1` addresses
- **[MAJOR]** Fix `/localhost/g` regex: use negative lookbehind/lookahead `(?<![a-zA-Z0-9-])localhost(?![a-zA-Z0-9-])` so hyphenated model IDs like `my-localhost-model` are never corrupted (`\b` alone is insufficient because hyphens are not word characters)
- **[MINOR]** Extract `rewriteLocalHosts(content: string): string` as a pure exported function — transformation logic is now testable in isolation without any I/O mocking
- **[MINOR]** Fix misleading catch comment: the `exists()` guard already handles the file-not-found case; the catch is now documented as covering I/O errors (permission denied, etc.)

### `src/config/sync.test.ts`
- **[MAJOR]** Replace `p.includes('models.json') || true` (always evaluates to `true`) with `async () => true` in the three transformation tests — removes dead code and makes intent clear
- **[MINOR]** Add `writtenPath` assertion to the `127.0.0.1` transformation test so a wrong path in `path.join(dest, 'agent', 'models.json')` would be caught
- **[SUGGESTION]** Add a `rewriteLocalHosts` describe block with 5 focused unit tests, including a regression test confirming `my-localhost-model` is not corrupted

## Testing

All 185 tests passing, type-check clean ✅